### PR TITLE
Add notebook with data leak fix

### DIFF
--- a/src/FixDataLeak_RandomForest.ipynb
+++ b/src/FixDataLeak_RandomForest.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After reusing the existing code to prepare and fit additional supervised models to our training data, I was surprised by the results: Each of the models that I tried would result in extremely strong performance on the training data as well as the validation data. If we were overfitting on the training data, the model performance on the test data should be relatively poor. However, it was performing well on the test data too. Still, I was concerned because the results seemed too good to be true. I'm fairly confident that were were introducing [\"data leakage\"](https://towardsdatascience.com/data-leakage-in-machine-learning-how-it-can-be-detected-and-minimize-the-risk-8ef4e3a97562) with the original process.\n",
+    "\n",
+    "What we were doing wrong was this: We were passing the full dataset into the normalizeData() function before splitting it into train and test sets. By doing this, we were \"leaking\" information from the testing set into the training set because the full set is being used for calculations and aggregations. As a result, the model gets some information about the distribution of the testing set during training. We were giving the model a peak of the real answers in an indirect way, resulting in overfitting on the testing data.\n",
+    "\n",
+    "To fix the data leak, we can split the dataset into training and testing sets and run the normalization function on the sets separately. The testing set remains unseen, which will result in a more performant model when it's used with real-world data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "import sklearn.metrics as m\n",
+    "from datetime import datetime, timedelta\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_path = \"../data/features_encoded.csv\"\n",
+    "raw_data = pd.read_csv(input_path, header=0, skiprows=None, index_col=None, delimiter=\",\")\n",
+    "\n",
+    "labels = raw_data['malicious'].apply(lambda x: 1 if x else 0)\n",
+    "features = raw_data.drop('malicious', axis=1)\n",
+    "\n",
+    "train_features = features.iloc[:80000, :]\n",
+    "test_features = features.iloc[80000:, :]\n",
+    "train_labels = labels[:80000]\n",
+    "test_labels = labels[80000:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculateNormalizationParams(data):\n",
+    "    means = data.mean()\n",
+    "    stdevs = data.std()\n",
+    "    stdevs[stdevs == 0] = 1  # Replace 0 std to avoid division by zero\n",
+    "    return means, stdevs\n",
+    "\n",
+    "def applyNormalization(data, means, stdevs):\n",
+    "    return (data - means) / stdevs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "means, stdevs = calculateNormalizationParams(train_features)\n",
+    "normalizedTrainFeatures = applyNormalization(train_features, means, stdevs)\n",
+    "normalizedTestFeatures = applyNormalization(test_features, means, stdevs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def acc(data, labels, n, d):\n",
+    "    t0 = datetime.now()\n",
+    "    rf = RandomForestClassifier(n_estimators=n, max_depth=d, random_state=0).fit(data, labels)\n",
+    "    predictions = rf.predict(data)\n",
+    "    tn = datetime.now() - t0\n",
+    "    tn = tn - timedelta(microseconds=tn.microseconds)\n",
+    "    return (n, d, m.accuracy_score(labels, predictions), tn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_vector = [50, 100, 250, 500]\n",
+    "d_vector = [2, 3, 5, 10, 13, 20]\n",
+    "scores = [acc(normalizedTrainFeatures, train_labels, n, d) for n in n_vector for d in d_vector]\n",
+    "for score in scores:\n",
+    "    print(f\"n = {score[0]}, d = {score[1]}, accuracy = {score[2]}, t = {score[3]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rf = RandomForestClassifier(max_depth=20, random_state=0)\n",
+    "rf.fit(normalizedTrainFeatures, train_labels)\n",
+    "predictions = rf.predict(normalizedTestFeatures)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc = m.accuracy_score(test_labels, predictions)\n",
+    "prec = m.precision_score(test_labels, predictions)\n",
+    "recall = m.recall_score(test_labels, predictions)\n",
+    "print(\"Accuracy score:\", acc)\n",
+    "print(\"Precision score:\", prec)\n",
+    "print(\"Recall score:\", recall)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.ConfusionMatrixDisplay(m.confusion_matrix(test_labels, predictions)).plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
After reusing the existing code to prepare and fit additional supervised models to our training data, I was surprised by the results: Each of the models that I tried would result in extremely strong performance on the training data as well as the validation data. If we were over-fitting on the training data, the model performance on the test data should be relatively poor. However, it was performing well on the test data too. Still, I was concerned because the results seemed too good to be true. I'm fairly confident that were were introducing ["data leakage"](https://towardsdatascience.com/data-leakage-in-machine-learning-how-it-can-be-detected-and-minimize-the-risk-8ef4e3a97562) with the original process.

What we were doing wrong was this: We were passing the full dataset into the normalizeData() function before splitting it into train and test sets. By doing this, we were "leaking" information from the testing set into the training set because the full set is being used for calculations and aggregations. As a result, the model gets some information about the distribution of the testing set during training. We were giving the model a peak of the real answers in an indirect way, resulting in over-fitting on the testing data.

To fix the data leak, we can split the dataset into training and testing sets and run the normalization function on the sets separately. The testing set remains unseen, which will result in a more performant model when it's used with real-world data.